### PR TITLE
feat: 設定ファイル読み込み機能の実装 (Closes #2)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,19 @@
+# gminor アプリケーション設定ファイル
+
+database:
+  host: localhost
+  port: 5432
+  name: gminor_db
+
+logging:
+  level: INFO
+  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+github:
+  api_base_url: https://api.github.com
+  timeout: 30
+
+application:
+  name: gminor
+  version: 1.0.0
+  environment: development

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,115 @@
+# gminor アプリケーション設定ファイルのサンプル
+# このファイルをconfig.yamlとしてコピーして使用してください
+
+# データベース設定
+database:
+  host: localhost
+  port: 5432
+  name: gminor_db
+  user: gminor_user
+  password: your_password_here
+  
+  # 接続プール設定
+  pool:
+    min_connections: 2
+    max_connections: 10
+    timeout: 30
+
+# ログ設定
+logging:
+  level: INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
+  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  
+  # ファイル出力設定
+  file:
+    enabled: true
+    path: logs/app.log
+    max_size: 10485760  # 10MB
+    backup_count: 5
+    
+  # コンソール出力設定
+  console:
+    enabled: true
+    colorized: true
+
+# GitHub API設定
+github:
+  api_token: your_github_token_here
+  api_base_url: https://api.github.com
+  timeout: 30
+  retry_count: 3
+  retry_delay: 1
+
+# アプリケーション設定
+application:
+  name: gminor
+  version: 1.0.0
+  environment: development  # development, staging, production
+  
+  # データディレクトリ設定
+  directories:
+    data: ./data
+    output: ./output
+    temp: ./temp
+    
+  # 処理設定
+  processing:
+    batch_size: 100
+    max_workers: 4
+    timeout: 300
+
+# 外部サービス設定
+services:
+  # API設定
+  api:
+    base_url: http://localhost:8000
+    version: v1
+    auth_required: false
+    
+  # キャッシュ設定
+  cache:
+    enabled: true
+    type: memory  # memory, redis
+    ttl: 3600  # 1時間
+    
+    # Redis設定（type: redisの場合）
+    redis:
+      host: localhost
+      port: 6379
+      db: 0
+
+# セキュリティ設定
+security:
+  # 暗号化設定
+  encryption:
+    algorithm: AES-256
+    key_rotation_days: 90
+    
+  # アクセス制御
+  access_control:
+    enabled: true
+    max_attempts: 5
+    lockout_duration: 300  # 5分
+
+# 通知設定
+notifications:
+  enabled: false
+  
+  # メール通知
+  email:
+    smtp_host: smtp.gmail.com
+    smtp_port: 587
+    use_tls: true
+    from_address: noreply@example.com
+    
+  # Slack通知
+  slack:
+    webhook_url: https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+    channel: "#general"
+    username: gminor-bot
+
+# 開発環境設定
+development:
+  debug: true
+  auto_reload: true
+  profiling: false

--- a/src/business_layer/config_loader.py
+++ b/src/business_layer/config_loader.py
@@ -1,0 +1,110 @@
+"""設定ファイル読み込みモジュール"""
+import os
+from pathlib import Path
+from typing import Dict, Any, Optional, Callable, Union
+import yaml
+
+
+class ConfigError(Exception):
+    """設定関連のエラー"""
+    pass
+
+
+class ConfigLoader:
+    """YAML設定ファイルを読み込むクラス"""
+    
+    def load_config(
+        self, 
+        config_path: Union[str, Path], 
+        defaults: Optional[Dict[str, Any]] = None,
+        validation_rules: Optional[Dict[str, Callable]] = None
+    ) -> Dict[str, Any]:
+        """
+        設定ファイルを読み込み、検証済み設定を返す
+        
+        Args:
+            config_path: 設定ファイルのパス
+            defaults: デフォルト設定値の辞書
+            validation_rules: 検証ルールの辞書（キーパス: 検証関数）
+            
+        Returns:
+            読み込んだ設定の辞書
+            
+        Raises:
+            ConfigError: ファイルが見つからない、形式が不正、検証エラーなど
+        """
+        config_path = Path(config_path).resolve()
+        
+        self._validate_file_exists(config_path)
+        config = self._load_yaml_file(config_path)
+        
+        if defaults:
+            config = self._merge_defaults(defaults, config)
+        
+        if validation_rules:
+            self._validate_config(config, validation_rules)
+        
+        return config
+    
+    def _validate_file_exists(self, config_path: Path) -> None:
+        """ファイルの存在を確認する"""
+        if not config_path.exists():
+            raise ConfigError(f"設定ファイルが見つかりません: {config_path}")
+    
+    def _load_yaml_file(self, config_path: Path) -> Dict[str, Any]:
+        """YAMLファイルを読み込む"""
+        try:
+            with config_path.open('r', encoding='utf-8') as f:
+                content = f.read()
+                
+                if not content.strip():
+                    raise ConfigError("設定ファイルが空です")
+                
+                config = yaml.safe_load(content)
+                
+                if config is None:
+                    raise ConfigError("設定ファイルが空です")
+                    
+                return config
+                    
+        except yaml.YAMLError as e:
+            raise ConfigError(f"設定ファイルの形式が不正です: {e}")
+        except Exception as e:
+            if isinstance(e, ConfigError):
+                raise
+            raise ConfigError(f"設定ファイルの読み込みに失敗しました: {e}")
+    
+    def _merge_defaults(self, defaults: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+        """デフォルト値をマージする"""
+        result = defaults.copy()
+        
+        def deep_merge(base: Dict[str, Any], update: Dict[str, Any]) -> Dict[str, Any]:
+            for key, value in update.items():
+                if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+                    base[key] = deep_merge(base[key], value)
+                else:
+                    base[key] = value
+            return base
+        
+        return deep_merge(result, config)
+    
+    def _validate_config(self, config: Dict[str, Any], rules: Dict[str, Callable]) -> None:
+        """設定値を検証する"""
+        for key_path, validator in rules.items():
+            value = self._get_value_by_path(config, key_path)
+            
+            if not validator(value):
+                raise ConfigError(f"設定値が不正です: {key_path} = {value}")
+    
+    def _get_value_by_path(self, config: Dict[str, Any], path: str) -> Any:
+        """ドット区切りのパスから値を取得する"""
+        keys = path.split('.')
+        value = config
+        
+        for key in keys:
+            if isinstance(value, dict) and key in value:
+                value = value[key]
+            else:
+                return None
+        
+        return value

--- a/src/business_layer/config_loader.py
+++ b/src/business_layer/config_loader.py
@@ -1,5 +1,5 @@
 """設定ファイル読み込みモジュール"""
-import os
+import copy
 from pathlib import Path
 from typing import Dict, Any, Optional, Callable, Union
 import yaml
@@ -55,12 +55,7 @@ class ConfigLoader:
         """YAMLファイルを読み込む"""
         try:
             with config_path.open('r', encoding='utf-8') as f:
-                content = f.read()
-                
-                if not content.strip():
-                    raise ConfigError("設定ファイルが空です")
-                
-                config = yaml.safe_load(content)
+                config = yaml.safe_load(f)
                 
                 if config is None:
                     raise ConfigError("設定ファイルが空です")
@@ -76,7 +71,7 @@ class ConfigLoader:
     
     def _merge_defaults(self, defaults: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
         """デフォルト値をマージする"""
-        result = defaults.copy()
+        result = copy.deepcopy(defaults)
         
         def deep_merge(base: Dict[str, Any], update: Dict[str, Any]) -> Dict[str, Any]:
             for key, value in update.items():

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,145 @@
+"""設定ファイル読み込み機能のテスト"""
+import os
+import tempfile
+from pathlib import Path
+import pytest
+import yaml
+from src.business_layer.config_loader import ConfigLoader, ConfigError
+
+
+class TestConfigLoader:
+    """ConfigLoaderのテストクラス"""
+
+    def setup_method(self):
+        """各テストメソッドの前処理"""
+        self.loader = ConfigLoader()
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        """各テストメソッドの後処理"""
+        import shutil
+        shutil.rmtree(self.temp_dir)
+
+    def test_正常な設定ファイルを読み込める(self):
+        """正常系: 有効なYAMLファイルを読み込めることを確認"""
+        config_data = {
+            "database": {
+                "host": "localhost",
+                "port": 5432,
+                "name": "testdb"
+            },
+            "logging": {
+                "level": "INFO",
+                "format": "%(asctime)s - %(message)s"
+            }
+        }
+        
+        config_path = os.path.join(self.temp_dir, "config.yaml")
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+        
+        result = self.loader.load_config(config_path)
+        
+        assert result == config_data
+        assert result["database"]["host"] == "localhost"
+        assert result["database"]["port"] == 5432
+        assert result["logging"]["level"] == "INFO"
+
+    def test_存在しないファイルの場合エラーを発生させる(self):
+        """異常系: 存在しないファイルを指定した場合、ConfigErrorが発生することを確認"""
+        non_existent_path = os.path.join(self.temp_dir, "non_existent.yaml")
+        
+        with pytest.raises(ConfigError) as exc_info:
+            self.loader.load_config(non_existent_path)
+        
+        assert "設定ファイルが見つかりません" in str(exc_info.value)
+
+    def test_不正なYAML形式の場合エラーを発生させる(self):
+        """異常系: 不正なYAML形式のファイルの場合、ConfigErrorが発生することを確認"""
+        config_path = os.path.join(self.temp_dir, "invalid.yaml")
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write("invalid: yaml: content:\n  - without proper: formatting")
+        
+        with pytest.raises(ConfigError) as exc_info:
+            self.loader.load_config(config_path)
+        
+        assert "設定ファイルの形式が不正です" in str(exc_info.value)
+
+    def test_空のファイルの場合エラーを発生させる(self):
+        """異常系: 空のファイルの場合、ConfigErrorが発生することを確認"""
+        config_path = os.path.join(self.temp_dir, "empty.yaml")
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write("")
+        
+        with pytest.raises(ConfigError) as exc_info:
+            self.loader.load_config(config_path)
+        
+        assert "設定ファイルが空です" in str(exc_info.value)
+
+    def test_デフォルト値を適用できる(self):
+        """正常系: デフォルト値を設定できることを確認"""
+        config_data = {
+            "database": {
+                "host": "localhost"
+            }
+        }
+        
+        config_path = os.path.join(self.temp_dir, "partial.yaml")
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+        
+        defaults = {
+            "database": {
+                "port": 5432,
+                "name": "defaultdb"
+            },
+            "logging": {
+                "level": "WARNING"
+            }
+        }
+        
+        result = self.loader.load_config(config_path, defaults=defaults)
+        
+        assert result["database"]["host"] == "localhost"  # 設定ファイルの値
+        assert result["database"]["port"] == 5432  # デフォルト値
+        assert result["database"]["name"] == "defaultdb"  # デフォルト値
+        assert result["logging"]["level"] == "WARNING"  # デフォルト値
+
+    def test_相対パスを絶対パスに変換できる(self):
+        """正常系: 相対パスを指定した場合でも読み込めることを確認"""
+        config_data = {"test": "value"}
+        
+        # 現在のディレクトリを一時ディレクトリに変更
+        original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        
+        try:
+            with open("config.yaml", "w", encoding="utf-8") as f:
+                yaml.dump(config_data, f)
+            
+            result = self.loader.load_config("config.yaml")
+            assert result == config_data
+        finally:
+            os.chdir(original_cwd)
+
+    def test_設定値の検証機能が動作する(self):
+        """正常系: バリデーション機能が正しく動作することを確認"""
+        config_data = {
+            "database": {
+                "port": "invalid_port"  # 数値であるべき
+            }
+        }
+        
+        config_path = os.path.join(self.temp_dir, "invalid_value.yaml")
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+        
+        # バリデーションルールを定義
+        validation_rules = {
+            "database.port": lambda x: isinstance(x, int) and 1 <= x <= 65535
+        }
+        
+        with pytest.raises(ConfigError) as exc_info:
+            self.loader.load_config(config_path, validation_rules=validation_rules)
+        
+        assert "設定値が不正です" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- config.yamlファイルからアプリケーション設定を読み込む機能を実装しました
- TDD（テスト駆動開発）の原則に従い、テストを先に書いてから実装を行いました
- カスタム例外、デフォルト値のマージ、バリデーション機能を含む完全な実装です

## 実装内容
### ConfigLoaderクラス
- `load_config()`: YAML設定ファイルの読み込みメソッド
- デフォルト値の深いマージ機能
- ドット記法による設定値の検証機能
- 適切なエラーハンドリング（ConfigError例外）

### テストケース
以下のケースをカバーする包括的なテストを実装:
- ✅ 正常な設定ファイルの読み込み
- ✅ 存在しないファイルのエラーハンドリング
- ✅ 不正なYAML形式のエラーハンドリング
- ✅ 空ファイルのエラーハンドリング
- ✅ デフォルト値の適用
- ✅ 設定値のバリデーション

### 設定ファイル
- `config.yaml`: 基本的な設定ファイル
- `config.yaml.example`: 詳細なコメント付きのサンプル設定

## Test plan
- [x] 単体テスト: `python3 run_tests_green.py` - 全6テストがパス
- [x] 統合テスト: `python3 test_real_config.py` - 実際のconfig.yamlを使用したテストがパス
- [x] デフォルト値のマージ機能の動作確認
- [x] バリデーション機能の動作確認

## 関連Issue
Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)