### PR TITLE
feat: SQLAlchemyモデルの定義 (Closes #3)

### DIFF
--- a/src/data_layer/models.py
+++ b/src/data_layer/models.py
@@ -1,0 +1,223 @@
+"""SQLAlchemyモデル定義
+
+このモジュールはgminorアプリケーションのデータベースモデルを定義します。
+- PullRequest: GitHubプルリクエストの情報
+- WeeklyMetrics: 週次集計データ（キャッシュ用）
+- SyncStatus: リポジトリ同期状態の管理
+"""
+from datetime import datetime, timezone, date
+from typing import Optional, ClassVar, Set
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Integer,
+    String,
+    UniqueConstraint,
+    Index,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import validates
+
+# SQLAlchemyのベースクラス
+Base = declarative_base()
+
+
+class DatabaseError(Exception):
+    """データベース関連のエラー"""
+    pass
+
+
+class PullRequest(Base):
+    """プルリクエストモデル
+    
+    GitHubのプルリクエスト情報を格納するモデル。
+    リポジトリとPR番号の組み合わせで一意性を保証する。
+    """
+    __tablename__ = 'pull_requests'
+    
+    # 主キー
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    
+    # 基本フィールド
+    repo_name = Column(String(255), nullable=False, comment="リポジトリ名（owner/repo形式）")
+    pr_number = Column(Integer, nullable=False, comment="プルリクエスト番号")
+    author = Column(String(255), nullable=False, comment="作成者のユーザー名")
+    title = Column(String(1000), nullable=False, comment="プルリクエストのタイトル")
+    merged_at = Column(DateTime(timezone=True), nullable=True, comment="マージ日時（未マージの場合はNULL）")
+    
+    # タイムスタンプ
+    created_at = Column(DateTime(timezone=True), nullable=False, comment="作成日時")
+    updated_at = Column(DateTime(timezone=True), nullable=False, comment="更新日時")
+    
+    # 制約とインデックス
+    __table_args__ = (
+        UniqueConstraint('repo_name', 'pr_number', name='uq_repo_pr_number'),
+        Index('idx_repo_name', 'repo_name'),
+        Index('idx_author', 'author'),
+        Index('idx_merged_at', 'merged_at'),
+        Index('idx_created_at', 'created_at'),
+    )
+    
+    @property
+    def is_merged(self) -> bool:
+        """マージ済みかどうかを判定"""
+        return self.merged_at is not None
+    
+    def get_full_identifier(self) -> str:
+        """完全識別子を取得（repo_name#pr_number形式）"""
+        return f"{self.repo_name}#{self.pr_number}"
+    
+    def __repr__(self) -> str:
+        return (f"<PullRequest(id={self.id}, repo_name='{self.repo_name}', "
+                f"pr_number={self.pr_number}, author='{self.author}', "
+                f"merged={self.is_merged})>")
+
+
+class WeeklyMetrics(Base):
+    """週次メトリクスモデル（キャッシュ用）
+    
+    週単位での集計データを格納してパフォーマンスを向上させるためのモデル。
+    週の開始日とリポジトリ名で一意性を保証する。
+    """
+    __tablename__ = 'weekly_metrics'
+    
+    # 主キー
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    
+    # 基本フィールド
+    week_start_date = Column(Date, nullable=False, comment="週の開始日（月曜日）")
+    repo_name = Column(String(255), nullable=False, comment="リポジトリ名（owner/repo形式）")
+    pr_count = Column(Integer, nullable=False, default=0, comment="総PR数")
+    merged_pr_count = Column(Integer, nullable=False, default=0, comment="マージされたPR数")
+    total_authors = Column(Integer, nullable=False, default=0, comment="ユニークな作成者数")
+    
+    # タイムスタンプ
+    created_at = Column(DateTime(timezone=True), nullable=False, comment="作成日時")
+    updated_at = Column(DateTime(timezone=True), nullable=False, comment="更新日時")
+    
+    # 制約とインデックス
+    __table_args__ = (
+        UniqueConstraint('week_start_date', 'repo_name', name='uq_week_repo'),
+        Index('idx_week_start_date', 'week_start_date'),
+        Index('idx_weekly_repo_name', 'repo_name'),
+        Index('idx_week_repo_composite', 'week_start_date', 'repo_name'),
+    )
+    
+    @validates('pr_count', 'merged_pr_count', 'total_authors')
+    def validate_non_negative(self, key: str, value: int) -> int:
+        """非負数の検証
+        
+        Args:
+            key: フィールド名
+            value: 設定する値
+            
+        Returns:
+            int: 検証済みの値
+            
+        Raises:
+            ValueError: 負数が指定された場合
+        """
+        if value < 0:
+            raise ValueError(f"{key} must be non-negative")
+        return value
+    
+    @property
+    def merge_rate(self) -> float:
+        """マージ率を計算（0.0-1.0）"""
+        if self.pr_count == 0:
+            return 0.0
+        return self.merged_pr_count / self.pr_count
+    
+    @property
+    def week_end_date(self) -> date:
+        """週の終了日を計算（日曜日）"""
+        from datetime import timedelta
+        return self.week_start_date + timedelta(days=6)
+    
+    def get_week_range_str(self) -> str:
+        """週の範囲を文字列で取得"""
+        return f"{self.week_start_date} - {self.week_end_date}"
+    
+    def __repr__(self) -> str:
+        return (f"<WeeklyMetrics(id={self.id}, week_start_date={self.week_start_date}, "
+                f"repo_name='{self.repo_name}', pr_count={self.pr_count}, "
+                f"merge_rate={self.merge_rate:.2f})>")
+
+
+class SyncStatus(Base):
+    """同期状態管理モデル
+    
+    各リポジトリの同期状態を管理するためのモデル。
+    GitHub APIからのデータ取得進捗とエラー状況を追跡する。
+    """
+    __tablename__ = 'sync_status'
+    
+    # ステータスの有効値を定数として定義
+    VALID_STATUSES: ClassVar[Set[str]] = {'pending', 'in_progress', 'completed', 'error'}
+    
+    # 主キー
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    
+    # 基本フィールド
+    repo_name = Column(String(255), nullable=False, unique=True, comment="リポジトリ名（owner/repo形式）")
+    last_synced_at = Column(DateTime(timezone=True), nullable=True, comment="最終同期日時")
+    last_pr_number = Column(Integer, nullable=True, comment="最後に処理されたPR番号")
+    status = Column(String(50), nullable=False, default='pending', comment="同期ステータス")
+    error_message = Column(String(2000), nullable=True, comment="エラーメッセージ（エラー時のみ）")
+    
+    # タイムスタンプ
+    created_at = Column(DateTime(timezone=True), nullable=False, comment="作成日時")
+    updated_at = Column(DateTime(timezone=True), nullable=False, comment="更新日時")
+    
+    # インデックス
+    __table_args__ = (
+        Index('idx_sync_repo_name', 'repo_name'),
+        Index('idx_sync_status', 'status'),
+        Index('idx_last_synced_at', 'last_synced_at'),
+    )
+    
+    @validates('status')
+    def validate_status(self, key: str, value: str) -> str:
+        """ステータスの検証
+        
+        Args:
+            key: フィールド名（'status'）
+            value: 設定する値
+            
+        Returns:
+            str: 検証済みのステータス値
+            
+        Raises:
+            ValueError: 無効なステータスが指定された場合
+        """
+        if value not in self.VALID_STATUSES:
+            raise ValueError(f"Status must be one of {self.VALID_STATUSES}")
+        return value
+    
+    def is_completed(self) -> bool:
+        """同期が完了しているかを判定"""
+        return self.status == 'completed'
+    
+    def is_error(self) -> bool:
+        """エラー状態かを判定"""
+        return self.status == 'error'
+    
+    def mark_completed(self, last_pr_number: Optional[int] = None) -> None:
+        """完了状態に設定"""
+        self.status = 'completed'
+        self.error_message = None
+        if last_pr_number is not None:
+            self.last_pr_number = last_pr_number
+        self.last_synced_at = datetime.now(timezone.utc)
+        self.updated_at = datetime.now(timezone.utc)
+    
+    def mark_error(self, error_message: str) -> None:
+        """エラー状態に設定"""
+        self.status = 'error'
+        self.error_message = error_message
+        self.updated_at = datetime.now(timezone.utc)
+    
+    def __repr__(self) -> str:
+        return (f"<SyncStatus(id={self.id}, repo_name='{self.repo_name}', "
+                f"status='{self.status}', last_pr_number={self.last_pr_number})>")

--- a/src/data_layer/models.py
+++ b/src/data_layer/models.py
@@ -5,7 +5,7 @@
 - WeeklyMetrics: 週次集計データ（キャッシュ用）
 - SyncStatus: リポジトリ同期状態の管理
 """
-from datetime import datetime, timezone, date
+from datetime import datetime, timezone, date, timedelta
 from typing import Optional, ClassVar, Set
 from sqlalchemy import (
     Column,
@@ -46,9 +46,9 @@ class PullRequest(Base):
     title = Column(String(1000), nullable=False, comment="プルリクエストのタイトル")
     merged_at = Column(DateTime(timezone=True), nullable=True, comment="マージ日時（未マージの場合はNULL）")
     
-    # タイムスタンプ
-    created_at = Column(DateTime(timezone=True), nullable=False, comment="作成日時")
-    updated_at = Column(DateTime(timezone=True), nullable=False, comment="更新日時")
+    # タイムスタンプ（自動設定）
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), comment="作成日時")
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), comment="更新日時")
     
     # 制約とインデックス
     __table_args__ = (
@@ -92,16 +92,15 @@ class WeeklyMetrics(Base):
     merged_pr_count = Column(Integer, nullable=False, default=0, comment="マージされたPR数")
     total_authors = Column(Integer, nullable=False, default=0, comment="ユニークな作成者数")
     
-    # タイムスタンプ
-    created_at = Column(DateTime(timezone=True), nullable=False, comment="作成日時")
-    updated_at = Column(DateTime(timezone=True), nullable=False, comment="更新日時")
+    # タイムスタンプ（自動設定）
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), comment="作成日時")
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), comment="更新日時")
     
     # 制約とインデックス
     __table_args__ = (
         UniqueConstraint('week_start_date', 'repo_name', name='uq_week_repo'),
         Index('idx_week_start_date', 'week_start_date'),
         Index('idx_weekly_repo_name', 'repo_name'),
-        Index('idx_week_repo_composite', 'week_start_date', 'repo_name'),
     )
     
     @validates('pr_count', 'merged_pr_count', 'total_authors')
@@ -132,7 +131,6 @@ class WeeklyMetrics(Base):
     @property
     def week_end_date(self) -> date:
         """週の終了日を計算（日曜日）"""
-        from datetime import timedelta
         return self.week_start_date + timedelta(days=6)
     
     def get_week_range_str(self) -> str:
@@ -166,9 +164,9 @@ class SyncStatus(Base):
     status = Column(String(50), nullable=False, default='pending', comment="同期ステータス")
     error_message = Column(String(2000), nullable=True, comment="エラーメッセージ（エラー時のみ）")
     
-    # タイムスタンプ
-    created_at = Column(DateTime(timezone=True), nullable=False, comment="作成日時")
-    updated_at = Column(DateTime(timezone=True), nullable=False, comment="更新日時")
+    # タイムスタンプ（自動設定）
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), comment="作成日時")
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), comment="更新日時")
     
     # インデックス
     __table_args__ = (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,332 @@
+"""SQLAlchemyモデルのテスト"""
+import pytest
+from datetime import datetime, timezone
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker, scoped_session
+from sqlalchemy.exc import IntegrityError
+
+from src.data_layer.models import (
+    Base, 
+    DatabaseError, 
+    PullRequest, 
+    WeeklyMetrics, 
+    SyncStatus
+)
+
+
+class TestDatabaseModels:
+    """データベースモデルのテストクラス"""
+    
+    @pytest.fixture(scope="function")
+    def engine(self):
+        """インメモリSQLiteエンジンを作成"""
+        engine = create_engine("sqlite:///:memory:", echo=False)
+        Base.metadata.create_all(engine)
+        return engine
+    
+    @pytest.fixture(scope="function")
+    def session(self, engine):
+        """テスト用セッションを作成"""
+        Session = scoped_session(sessionmaker(bind=engine))
+        session = Session()
+        yield session
+        session.close()
+        Session.remove()
+
+
+class TestPullRequestModel(TestDatabaseModels):
+    """PullRequestモデルのテストクラス"""
+    
+    def test_PullRequestモデルが正常に作成できる(self, session):
+        """正常系: PullRequestオブジェクトが作成できることを確認"""
+        pr = PullRequest(
+            repo_name="test/repo",
+            pr_number=123,
+            author="test_author",
+            title="Test PR Title",
+            merged_at=datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        
+        session.add(pr)
+        session.commit()
+        
+        # データベースから取得して確認
+        saved_pr = session.query(PullRequest).filter_by(repo_name="test/repo", pr_number=123).first()
+        assert saved_pr is not None
+        assert saved_pr.repo_name == "test/repo"
+        assert saved_pr.pr_number == 123
+        assert saved_pr.author == "test_author"
+        assert saved_pr.title == "Test PR Title"
+        assert saved_pr.merged_at is not None
+    
+    def test_PullRequestの必須フィールドが設定されている(self, session):
+        """正常系: 必須フィールドがすべて設定されることを確認"""
+        pr = PullRequest(
+            repo_name="test/repo",
+            pr_number=456,
+            author="author2",
+            title="Another PR",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        
+        session.add(pr)
+        session.commit()
+        
+        saved_pr = session.query(PullRequest).filter_by(pr_number=456).first()
+        assert saved_pr.id is not None  # 自動生成される
+        assert saved_pr.repo_name == "test/repo"
+        assert saved_pr.pr_number == 456
+        assert saved_pr.author == "author2"
+        assert saved_pr.title == "Another PR"
+        assert saved_pr.merged_at is None  # まだマージされていない
+    
+    def test_PullRequestのユニーク制約が動作する(self, session):
+        """異常系: (repo_name, pr_number)のユニーク制約が動作することを確認"""
+        pr1 = PullRequest(
+            repo_name="test/repo",
+            pr_number=123,
+            author="author1",
+            title="First PR",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        session.add(pr1)
+        session.commit()
+        
+        # 同じrepo_name + pr_numberの組み合わせで別のPRを作成
+        pr2 = PullRequest(
+            repo_name="test/repo",
+            pr_number=123,  # 同じPR番号
+            author="author2",
+            title="Duplicate PR",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        session.add(pr2)
+        
+        with pytest.raises(IntegrityError):
+            session.commit()
+    
+    def test_PullRequestのテーブル名が正しい(self, engine):
+        """正常系: テーブル名が'pull_requests'であることを確認"""
+        # テーブル一覧を取得
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT name FROM sqlite_master WHERE type='table';"))
+            table_names = [row[0] for row in result]
+        
+        assert 'pull_requests' in table_names
+    
+    def test_PullRequestのインデックスが設定されている(self, engine):
+        """正常系: 適切なインデックスが設定されていることを確認"""
+        # SQLiteの場合、インデックス情報を取得
+        with engine.connect() as conn:
+            result = conn.execute(text("PRAGMA index_list('pull_requests');"))
+            indexes = list(result)
+        
+        # ユニークインデックスが存在することを確認
+        assert len(indexes) > 0
+
+
+class TestWeeklyMetricsModel(TestDatabaseModels):
+    """WeeklyMetricsモデルのテストクラス"""
+    
+    def test_WeeklyMetricsモデルが正常に作成できる(self, session):
+        """正常系: WeeklyMetricsオブジェクトが作成できることを確認"""
+        metrics = WeeklyMetrics(
+            week_start_date=datetime(2024, 1, 1).date(),
+            repo_name="test/repo",
+            pr_count=5,
+            merged_pr_count=3,
+            total_authors=2,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        
+        session.add(metrics)
+        session.commit()
+        
+        saved_metrics = session.query(WeeklyMetrics).first()
+        assert saved_metrics is not None
+        assert saved_metrics.week_start_date.year == 2024
+        assert saved_metrics.repo_name == "test/repo"
+        assert saved_metrics.pr_count == 5
+        assert saved_metrics.merged_pr_count == 3
+        assert saved_metrics.total_authors == 2
+    
+    def test_WeeklyMetricsのユニーク制約が動作する(self, session):
+        """異常系: (week_start_date, repo_name)のユニーク制約が動作することを確認"""
+        week_date = datetime(2024, 1, 1).date()
+        
+        metrics1 = WeeklyMetrics(
+            week_start_date=week_date,
+            repo_name="test/repo",
+            pr_count=5,
+            merged_pr_count=3,
+            total_authors=2,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        session.add(metrics1)
+        session.commit()
+        
+        # 同じ週・同じリポジトリで別のメトリクスを作成
+        metrics2 = WeeklyMetrics(
+            week_start_date=week_date,  # 同じ週
+            repo_name="test/repo",     # 同じリポジトリ
+            pr_count=10,
+            merged_pr_count=8,
+            total_authors=4,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        session.add(metrics2)
+        
+        with pytest.raises(IntegrityError):
+            session.commit()
+    
+    def test_WeeklyMetricsのテーブル名が正しい(self, engine):
+        """正常系: テーブル名が'weekly_metrics'であることを確認"""
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT name FROM sqlite_master WHERE type='table';"))
+            table_names = [row[0] for row in result]
+        
+        assert 'weekly_metrics' in table_names
+
+
+class TestSyncStatusModel(TestDatabaseModels):
+    """SyncStatusモデルのテストクラス"""
+    
+    def test_SyncStatusモデルが正常に作成できる(self, session):
+        """正常系: SyncStatusオブジェクトが作成できることを確認"""
+        sync_status = SyncStatus(
+            repo_name="test/repo",
+            last_synced_at=datetime.now(timezone.utc),
+            last_pr_number=150,
+            status="completed",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        
+        session.add(sync_status)
+        session.commit()
+        
+        saved_status = session.query(SyncStatus).first()
+        assert saved_status is not None
+        assert saved_status.repo_name == "test/repo"
+        assert saved_status.last_pr_number == 150
+        assert saved_status.status == "completed"
+        assert saved_status.last_synced_at is not None
+    
+    def test_SyncStatusのリポジトリ名ユニーク制約が動作する(self, session):
+        """異常系: repo_nameのユニーク制約が動作することを確認"""
+        status1 = SyncStatus(
+            repo_name="test/repo",
+            last_synced_at=datetime.now(timezone.utc),
+            last_pr_number=100,
+            status="in_progress",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        session.add(status1)
+        session.commit()
+        
+        # 同じリポジトリで別のSyncStatusを作成
+        status2 = SyncStatus(
+            repo_name="test/repo",  # 同じリポジトリ名
+            last_synced_at=datetime.now(timezone.utc),
+            last_pr_number=200,
+            status="completed",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        session.add(status2)
+        
+        with pytest.raises(IntegrityError):
+            session.commit()
+    
+    def test_SyncStatusのテーブル名が正しい(self, engine):
+        """正常系: テーブル名が'sync_status'であることを確認"""
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT name FROM sqlite_master WHERE type='table';"))
+            table_names = [row[0] for row in result]
+        
+        assert 'sync_status' in table_names
+
+
+class TestModelRelationships(TestDatabaseModels):
+    """モデル間のリレーションシップのテストクラス"""
+    
+    def test_リレーションシップが正常に動作する(self, session):
+        """正常系: モデル間のリレーションシップが正常に動作することを確認"""
+        # PullRequestを作成
+        pr = PullRequest(
+            repo_name="test/repo",
+            pr_number=123,
+            author="test_author",
+            title="Test PR",
+            merged_at=datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        
+        # WeeklyMetricsを作成
+        metrics = WeeklyMetrics(
+            week_start_date=datetime(2024, 1, 1).date(),
+            repo_name="test/repo",
+            pr_count=1,
+            merged_pr_count=1,
+            total_authors=1,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        
+        # SyncStatusを作成
+        sync_status = SyncStatus(
+            repo_name="test/repo",
+            last_synced_at=datetime.now(timezone.utc),
+            last_pr_number=123,
+            status="completed",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc)
+        )
+        
+        session.add_all([pr, metrics, sync_status])
+        session.commit()
+        
+        # リポジトリ名で関連するデータを取得できることを確認
+        repo_prs = session.query(PullRequest).filter_by(repo_name="test/repo").all()
+        repo_metrics = session.query(WeeklyMetrics).filter_by(repo_name="test/repo").all()
+        repo_status = session.query(SyncStatus).filter_by(repo_name="test/repo").first()
+        
+        assert len(repo_prs) == 1
+        assert len(repo_metrics) == 1
+        assert repo_status is not None
+        
+        # すべて同じリポジトリ名を持つことを確認
+        assert repo_prs[0].repo_name == "test/repo"
+        assert repo_metrics[0].repo_name == "test/repo"
+        assert repo_status.repo_name == "test/repo"
+
+
+class TestDatabaseError:
+    """DatabaseError例外のテスト"""
+    
+    def test_DatabaseErrorが正常に発生する(self):
+        """正常系: DatabaseError例外が正常に発生することを確認"""
+        with pytest.raises(DatabaseError) as exc_info:
+            raise DatabaseError("テストエラー")
+        
+        assert "テストエラー" in str(exc_info.value)
+        assert isinstance(exc_info.value, Exception)
+    
+    def test_DatabaseErrorに詳細メッセージを設定できる(self):
+        """正常系: DatabaseErrorに詳細なエラーメッセージを設定できることを確認"""
+        error_msg = "データベース接続に失敗しました: connection timeout"
+        
+        with pytest.raises(DatabaseError) as exc_info:
+            raise DatabaseError(error_msg)
+        
+        assert error_msg == str(exc_info.value)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -128,6 +128,49 @@ class TestPullRequestModel(TestDatabaseModels):
         
         # ユニークインデックスが存在することを確認
         assert len(indexes) > 0
+    
+    def test_PullRequest_is_mergedプロパティ(self, session):
+        """正常系: is_mergedプロパティが正しく動作することを確認"""
+        now = datetime.now(timezone.utc)
+        
+        # merged_atがある場合
+        pr_merged = PullRequest(
+            repo_name="test/repo", 
+            pr_number=1, 
+            author="test", 
+            title="Merged PR",
+            created_at=now,
+            updated_at=now,
+            merged_at=now
+        )
+        assert pr_merged.is_merged is True
+        
+        # merged_atがない場合
+        pr_not_merged = PullRequest(
+            repo_name="test/repo", 
+            pr_number=2, 
+            author="test", 
+            title="Not merged PR",
+            created_at=now,
+            updated_at=now,
+            merged_at=None
+        )
+        assert pr_not_merged.is_merged is False
+    
+    def test_PullRequest_get_full_identifierメソッド(self, session):
+        """正常系: get_full_identifierメソッドが正しく動作することを確認"""
+        now = datetime.now(timezone.utc)
+        pr = PullRequest(
+            repo_name="owner/repository",
+            pr_number=123,
+            author="test_author",
+            title="Test PR",
+            created_at=now,
+            updated_at=now
+        )
+        
+        expected = "owner/repository#123"
+        assert pr.get_full_identifier() == expected
 
 
 class TestWeeklyMetricsModel(TestDatabaseModels):
@@ -194,6 +237,79 @@ class TestWeeklyMetricsModel(TestDatabaseModels):
             table_names = [row[0] for row in result]
         
         assert 'weekly_metrics' in table_names
+    
+    def test_WeeklyMetricsのバリデーションが負の値を拒否する(self):
+        """異常系: pr_countに負の値を設定するとValueErrorが発生することを確認"""
+        with pytest.raises(ValueError, match="pr_count must be non-negative"):
+            WeeklyMetrics(
+                week_start_date=datetime(2024, 1, 1).date(),
+                repo_name="test/repo",
+                pr_count=-1,
+                merged_pr_count=5,
+                total_authors=2,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc)
+            )
+    
+    def test_WeeklyMetricsのmerge_rateプロパティ(self):
+        """正常系: merge_rateプロパティが正しく計算されることを確認"""
+        now = datetime.now(timezone.utc)
+        
+        # PR数が0の場合
+        metrics_zero = WeeklyMetrics(
+            week_start_date=datetime(2024, 1, 1).date(),
+            repo_name="test/repo",
+            pr_count=0,
+            merged_pr_count=0,
+            total_authors=0,
+            created_at=now,
+            updated_at=now
+        )
+        assert metrics_zero.merge_rate == 0.0
+        
+        # 正常な計算
+        metrics_normal = WeeklyMetrics(
+            week_start_date=datetime(2024, 1, 1).date(),
+            repo_name="test/repo",
+            pr_count=10,
+            merged_pr_count=8,
+            total_authors=3,
+            created_at=now,
+            updated_at=now
+        )
+        assert metrics_normal.merge_rate == 0.8
+    
+    def test_WeeklyMetricsのweek_end_dateプロパティ(self):
+        """正常系: week_end_dateプロパティが正しく計算されることを確認"""
+        now = datetime.now(timezone.utc)
+        metrics = WeeklyMetrics(
+            week_start_date=datetime(2024, 1, 1).date(),  # 月曜日
+            repo_name="test/repo",
+            pr_count=5,
+            merged_pr_count=3,
+            total_authors=2,
+            created_at=now,
+            updated_at=now
+        )
+        
+        expected_end_date = datetime(2024, 1, 7).date()  # 日曜日
+        assert metrics.week_end_date == expected_end_date
+    
+    def test_WeeklyMetricsのget_week_range_strメソッド(self):
+        """正常系: get_week_range_strメソッドが正しい文字列を返すことを確認"""
+        now = datetime.now(timezone.utc)
+        metrics = WeeklyMetrics(
+            week_start_date=datetime(2024, 1, 1).date(),
+            repo_name="test/repo",
+            pr_count=5,
+            merged_pr_count=3,
+            total_authors=2,
+            created_at=now,
+            updated_at=now
+        )
+        
+        expected = "2024-01-01 - 2024-01-07"
+        assert metrics.get_week_range_str() == expected
 
 
 class TestSyncStatusModel(TestDatabaseModels):
@@ -254,6 +370,99 @@ class TestSyncStatusModel(TestDatabaseModels):
             table_names = [row[0] for row in result]
         
         assert 'sync_status' in table_names
+    
+    def test_SyncStatusのバリデーションが無効なステータスを拒否する(self):
+        """異常系: statusに無効な値を設定するとValueErrorが発生することを確認"""
+        with pytest.raises(ValueError, match="Status must be one of"):
+            SyncStatus(
+                repo_name="test/repo",
+                status="invalid_status",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc)
+            )
+    
+    def test_SyncStatusのis_completedメソッド(self):
+        """正常系: is_completedメソッドが正しく動作することを確認"""
+        now = datetime.now(timezone.utc)
+        
+        # 完了状態
+        sync_completed = SyncStatus(
+            repo_name="test/repo",
+            status="completed",
+            created_at=now,
+            updated_at=now
+        )
+        assert sync_completed.is_completed() is True
+        
+        # 未完了状態
+        sync_pending = SyncStatus(
+            repo_name="test/repo",
+            status="pending",
+            created_at=now,
+            updated_at=now
+        )
+        assert sync_pending.is_completed() is False
+    
+    def test_SyncStatusのis_errorメソッド(self):
+        """正常系: is_errorメソッドが正しく動作することを確認"""
+        now = datetime.now(timezone.utc)
+        
+        # エラー状態
+        sync_error = SyncStatus(
+            repo_name="test/repo",
+            status="error",
+            error_message="Test error",
+            created_at=now,
+            updated_at=now
+        )
+        assert sync_error.is_error() is True
+        
+        # 正常状態
+        sync_normal = SyncStatus(
+            repo_name="test/repo",
+            status="completed",
+            created_at=now,
+            updated_at=now
+        )
+        assert sync_normal.is_error() is False
+    
+    def test_SyncStatusのmark_completedメソッド(self):
+        """正常系: mark_completedメソッドが正しく動作することを確認"""
+        now = datetime.now(timezone.utc)
+        sync = SyncStatus(
+            repo_name="test/repo",
+            status="in_progress",
+            created_at=now,
+            updated_at=now
+        )
+        
+        # 完了マーク（PR番号なし）
+        sync.mark_completed()
+        assert sync.status == "completed"
+        assert sync.error_message is None
+        assert sync.last_synced_at is not None
+        assert sync.updated_at is not None
+        
+        # 完了マーク（PR番号あり）
+        sync.mark_completed(last_pr_number=150)
+        assert sync.last_pr_number == 150
+    
+    def test_SyncStatusのmark_errorメソッド(self):
+        """正常系: mark_errorメソッドが正しく動作することを確認"""
+        now = datetime.now(timezone.utc)
+        sync = SyncStatus(
+            repo_name="test/repo",
+            status="in_progress",
+            created_at=now,
+            updated_at=now
+        )
+        
+        error_msg = "Connection timeout"
+        sync.mark_error(error_msg)
+        
+        assert sync.status == "error"
+        assert sync.error_message == error_msg
+        assert sync.updated_at is not None
 
 
 class TestModelRelationships(TestDatabaseModels):


### PR DESCRIPTION
## Summary
- データベーススキーマに対応するSQLAlchemyモデルを実装しました
- TDD（テスト駆動開発）の原則に従い、テストファーストで開発を進めました
- 包括的なテストカバレッジとドキュメンテーションを提供しています

## 実装内容

### モデルクラス
- **PullRequest**: GitHubプルリクエスト情報の格納
  - フィールド: id, repo_name, pr_number, author, title, merged_at, created_at, updated_at
  - ユニーク制約: (repo_name, pr_number)
  - インデックス: repo_name, author, merged_at, created_at
  - プロパティ: `is_merged`, メソッド: `get_full_identifier()`

- **WeeklyMetrics**: 週次集計データのキャッシュ
  - フィールド: id, week_start_date, repo_name, pr_count, merged_pr_count, total_authors, created_at, updated_at  
  - ユニーク制約: (week_start_date, repo_name)
  - プロパティ: `merge_rate`, `week_end_date`
  - バリデーション: 非負数制約

- **SyncStatus**: 同期状態管理
  - フィールド: id, repo_name, last_synced_at, last_pr_number, status, error_message, created_at, updated_at
  - ユニーク制約: repo_name
  - ステータス管理: `is_completed()`, `is_error()`, `mark_completed()`, `mark_error()`

- **DatabaseError**: カスタム例外クラス

### 設計特徴
- 完全な型ヒント対応
- 詳細なドキュメンテーション（日本語コメント付き）
- パフォーマンスを考慮したインデックス設計
- データ整合性を保証するユニーク制約
- バリデーション機能とエラーハンドリング
- ビジネスロジック用のヘルパーメソッド

## テスト実装

### テストカバレッジ
- ✅ **PullRequestモデル**: 作成、必須フィールド、ユニーク制約、テーブル名、インデックス
- ✅ **WeeklyMetricsモデル**: 作成、ユニーク制約、テーブル名、バリデーション
- ✅ **SyncStatusモデル**: 作成、ユニーク制約、テーブル名、ステータス管理
- ✅ **モデル関係性**: リポジトリ名による関連データ取得
- ✅ **DatabaseError例外**: エラーメッセージ設定とキャッチ
- ✅ **ユニーク制約**: IntegrityError発生の確認

## Test plan
- [x] 構造検証テスト: `python3 verify_models.py` - ✅ 全検証項目パス
- [x] ビルド検証テスト: `python3 build_verification.py` - ✅ 4/4検証ステップパス
- [x] シンタックス検証: py_compile によるコンパイルチェック - ✅ パス
- [x] Issue要件検証: 全ての指定要件の実装確認 - ✅ パス
- [x] ドキュメント検証: クラス・モジュールレベルのドキュメント確認 - ✅ パス

## TDD実装プロセス
1. **RED Phase**: 失敗するテストを先に作成 - ✅ 完了
2. **GREEN Phase**: テストを通す最小限の実装 - ✅ 完了  
3. **REFACTOR Phase**: コード品質向上とリファクタリング - ✅ 完了

## データベーススキーマ
```sql
-- pull_requests テーブル
CREATE TABLE pull_requests (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    repo_name VARCHAR(255) NOT NULL,
    pr_number INTEGER NOT NULL,
    author VARCHAR(255) NOT NULL,
    title VARCHAR(1000) NOT NULL,
    merged_at DATETIME,
    created_at DATETIME NOT NULL,
    updated_at DATETIME NOT NULL,
    CONSTRAINT uq_repo_pr_number UNIQUE (repo_name, pr_number)
);

-- weekly_metrics テーブル  
CREATE TABLE weekly_metrics (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    week_start_date DATE NOT NULL,
    repo_name VARCHAR(255) NOT NULL,
    pr_count INTEGER NOT NULL DEFAULT 0,
    merged_pr_count INTEGER NOT NULL DEFAULT 0,
    total_authors INTEGER NOT NULL DEFAULT 0,
    created_at DATETIME NOT NULL,
    updated_at DATETIME NOT NULL,
    CONSTRAINT uq_week_repo UNIQUE (week_start_date, repo_name)
);

-- sync_status テーブル
CREATE TABLE sync_status (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    repo_name VARCHAR(255) NOT NULL UNIQUE,
    last_synced_at DATETIME,
    last_pr_number INTEGER,
    status VARCHAR(50) NOT NULL DEFAULT 'pending',
    error_message VARCHAR(2000),
    created_at DATETIME NOT NULL,
    updated_at DATETIME NOT NULL
);
```

## 関連Issue
Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)