### PR TITLE
追加CLIコマンドの実装（fetch, stats, cleanup, config）

### DIFF
--- a/src/business_layer/sync_manager.py
+++ b/src/business_layer/sync_manager.py
@@ -503,14 +503,12 @@ class SyncManager:
             
             for repository in repositories:
                 try:
-                    # 期間指定でPRを取得
-                    pr_data = []
-                    all_prs = self.github_client.fetch_merged_prs(repo=repository, since=start_datetime)
-                    
-                    # 期間内のPRのみフィルタリング
-                    for pr in all_prs:
-                        if pr['merged_at'] <= end_datetime:
-                            pr_data.append(pr)
+                    # 期間指定でPRを取得（APIレベルでフィルタリング）
+                    pr_data = self.github_client.fetch_merged_prs(
+                        repo=repository, 
+                        since=start_datetime, 
+                        until=end_datetime
+                    )
                     
                     if pr_data:
                         # データベースに保存

--- a/src/presentation_layer/cli.py
+++ b/src/presentation_layer/cli.py
@@ -359,7 +359,6 @@ def fetch(ctx, from_date: str, to_date: str):
     
     try:
         sync_manager = services['sync_manager']
-        # fetch_period_dataメソッドを使用（後で実装）
         result = sync_manager.fetch_period_data(repositories, from_date, to_date)
         
         if result['status'] == 'success':
@@ -400,16 +399,15 @@ def stats(ctx):
         click.echo(f"🔝 最高生産性: {summary['max_productivity']:.2f}")
         click.echo(f"🔻 最低生産性: {summary['min_productivity']:.2f}")
         
-        # リポジトリ別統計を取得（メソッドを後で実装）
-        if hasattr(metrics_service, 'get_repository_stats'):
-            repo_stats = metrics_service.get_repository_stats()
-            if repo_stats:
-                click.echo("\n📂 リポジトリ別統計")
-                click.echo("-" * 50)
-                for repo_name, stats in repo_stats.items():
-                    click.echo(f"\n{repo_name}:")
-                    click.echo(f"  PR数: {stats.get('pr_count', 0)}")
-                    click.echo(f"  貢献者数: {stats.get('unique_authors', 0)}")
+        # リポジトリ別統計を取得
+        repo_stats = metrics_service.get_repository_stats()
+        if repo_stats:
+            click.echo("\n📂 リポジトリ別統計")
+            click.echo("-" * 50)
+            for repo_name, stats in repo_stats.items():
+                click.echo(f"\n{repo_name}:")
+                click.echo(f"  PR数: {stats.get('pr_count', 0)}")
+                click.echo(f"  貢献者数: {stats.get('unique_authors', 0)}")
         
     except Exception as e:
         raise click.ClickException(f"統計情報の取得中にエラーが発生しました: {str(e)}")
@@ -441,18 +439,11 @@ def cleanup(ctx, before: str, yes: bool):
     timezone_handler, github_client, db_manager, aggregator = ctx.obj['components']
     
     try:
-        # cleanup_old_dataメソッドを使用（後で実装）
-        if hasattr(db_manager, 'cleanup_old_data'):
-            result = db_manager.cleanup_old_data(before)
-            
-            click.echo(f"✅ クリーンアップが完了しました")
-            click.echo(f"🗑️  削除されたPR: {result.get('deleted_prs', 0)}件")
-            click.echo(f"📊 削除されたメトリクス: {result.get('deleted_metrics', 0)}件")
-        else:
-            # 一時的な実装（後で改善）
-            click.echo("✅ クリーンアップが完了しました")
-            click.echo("🗑️  削除されたPR: 0件")
-            click.echo("📊 削除されたメトリクス: 0件")
+        result = db_manager.cleanup_old_data(before)
+        
+        click.echo(f"✅ クリーンアップが完了しました")
+        click.echo(f"🗑️  削除されたPR: {result.get('deleted_prs', 0)}件")
+        click.echo(f"📊 削除されたメトリクス: {result.get('deleted_metrics', 0)}件")
             
     except Exception as e:
         raise click.ClickException(f"クリーンアップ中にエラーが発生しました: {str(e)}")

--- a/src/presentation_layer/cli.py
+++ b/src/presentation_layer/cli.py
@@ -1,9 +1,10 @@
 """
-CLI コマンド実装（init・visualize）
+CLI コマンド実装（init・visualize・update・fetch・stats・cleanup・config）
 """
 import os
 from pathlib import Path
 from typing import Dict, Any, List, Optional
+from datetime import datetime
 
 import click
 import pandas as pd
@@ -313,6 +314,218 @@ def visualize(ctx):
     finally:
         # リソースのクリーンアップ
         db_manager.close()
+
+
+def validate_date_format(date_str: str) -> bool:
+    """日付形式の妥当性を検証する
+    
+    Args:
+        date_str: 検証する日付文字列（YYYY-MM-DD形式）
+        
+    Returns:
+        bool: 妥当な場合True
+    """
+    try:
+        datetime.strptime(date_str, '%Y-%m-%d')
+        return True
+    except ValueError:
+        return False
+
+
+@cli.command()
+@click.option('--from', 'from_date', help='開始日（YYYY-MM-DD）', required=True)
+@click.option('--to', 'to_date', help='終了日（YYYY-MM-DD）', required=True)
+@click.pass_context
+def fetch(ctx, from_date: str, to_date: str):
+    """特定期間のデータを再取得"""
+    # 日付形式の検証
+    if not validate_date_format(from_date) or not validate_date_format(to_date):
+        raise click.ClickException("日付形式が正しくありません。YYYY-MM-DD形式で指定してください。")
+    
+    click.echo(f"🔍 特定期間のデータ取得を開始しています...")
+    click.echo(f"📅 期間: {from_date} 〜 {to_date}")
+    
+    # コンテキストから依存関係を取得
+    config = ctx.obj['config']
+    timezone_handler, github_client, db_manager, aggregator = ctx.obj['components']
+    services = ctx.obj['services']
+    
+    repositories = config['github'].get('repositories', [])
+    if not repositories:
+        raise click.ClickException(
+            "設定ファイルにリポジトリが定義されていません。\n"
+            "config.yaml の github.repositories に対象リポジトリを追加してください。"
+        )
+    
+    try:
+        sync_manager = services['sync_manager']
+        # fetch_period_dataメソッドを使用（後で実装）
+        result = sync_manager.fetch_period_data(repositories, from_date, to_date)
+        
+        if result['status'] == 'success':
+            click.echo(f"✅ データ取得が完了しました！")
+            click.echo(f"📊 取得したPR数: {result.get('fetched_prs', 0)}")
+            click.echo(f"⏱️  実行時間: {result.get('duration_seconds', 0):.1f}秒")
+        else:
+            raise click.ClickException(f"データ取得に失敗しました: {result.get('error', 'Unknown error')}")
+            
+    except Exception as e:
+        raise click.ClickException(f"データ取得中にエラーが発生しました: {str(e)}")
+    finally:
+        db_manager.close()
+
+
+@cli.command()
+@click.pass_context
+def stats(ctx):
+    """統計情報表示"""
+    click.echo("📊 統計情報を取得しています...")
+    
+    # コンテキストから依存関係を取得
+    config = ctx.obj['config']
+    timezone_handler, github_client, db_manager, aggregator = ctx.obj['components']
+    services = ctx.obj['services']
+    
+    try:
+        metrics_service = services['metrics_service']
+        
+        # 基本統計情報を取得
+        summary = metrics_service.get_metrics_summary()
+        
+        click.echo("\n📊 統計情報")
+        click.echo("=" * 50)
+        click.echo(f"📅 総集計期間: {summary['total_weeks']}週")
+        click.echo(f"📋 総PR数: {summary['total_prs']}")
+        click.echo(f"📈 平均生産性: {summary['average_productivity']:.2f}")
+        click.echo(f"🔝 最高生産性: {summary['max_productivity']:.2f}")
+        click.echo(f"🔻 最低生産性: {summary['min_productivity']:.2f}")
+        
+        # リポジトリ別統計を取得（メソッドを後で実装）
+        if hasattr(metrics_service, 'get_repository_stats'):
+            repo_stats = metrics_service.get_repository_stats()
+            if repo_stats:
+                click.echo("\n📂 リポジトリ別統計")
+                click.echo("-" * 50)
+                for repo_name, stats in repo_stats.items():
+                    click.echo(f"\n{repo_name}:")
+                    click.echo(f"  PR数: {stats.get('pr_count', 0)}")
+                    click.echo(f"  貢献者数: {stats.get('unique_authors', 0)}")
+        
+    except Exception as e:
+        raise click.ClickException(f"統計情報の取得中にエラーが発生しました: {str(e)}")
+    finally:
+        db_manager.close()
+
+
+@cli.command()
+@click.option('--before', help='指定日以前のデータを削除（YYYY-MM-DD）', required=True)
+@click.option('--yes', is_flag=True, help='確認をスキップ')
+@click.pass_context
+def cleanup(ctx, before: str, yes: bool):
+    """データベースのクリーンアップ"""
+    # 日付形式の検証
+    if not validate_date_format(before):
+        raise click.ClickException("日付形式が正しくありません。YYYY-MM-DD形式で指定してください。")
+    
+    click.echo(f"🗑️  データベースのクリーンアップを開始します")
+    click.echo(f"⚠️  {before} 以前のデータを削除します")
+    
+    # 確認プロンプト
+    if not yes:
+        if not click.confirm("本当に削除しますか？"):
+            click.echo("❌ キャンセルされました")
+            return
+    
+    # コンテキストから依存関係を取得
+    config = ctx.obj['config']
+    timezone_handler, github_client, db_manager, aggregator = ctx.obj['components']
+    
+    try:
+        # cleanup_old_dataメソッドを使用（後で実装）
+        if hasattr(db_manager, 'cleanup_old_data'):
+            result = db_manager.cleanup_old_data(before)
+            
+            click.echo(f"✅ クリーンアップが完了しました")
+            click.echo(f"🗑️  削除されたPR: {result.get('deleted_prs', 0)}件")
+            click.echo(f"📊 削除されたメトリクス: {result.get('deleted_metrics', 0)}件")
+        else:
+            # 一時的な実装（後で改善）
+            click.echo("✅ クリーンアップが完了しました")
+            click.echo("🗑️  削除されたPR: 0件")
+            click.echo("📊 削除されたメトリクス: 0件")
+            
+    except Exception as e:
+        raise click.ClickException(f"クリーンアップ中にエラーが発生しました: {str(e)}")
+    finally:
+        db_manager.close()
+
+
+@cli.command()
+@click.option('--validate', is_flag=True, help='設定の妥当性を検証')
+@click.pass_context
+def config(ctx, validate: bool):
+    """設定確認"""
+    try:
+        # 設定を取得
+        config_data = ctx.obj['config']
+        
+        click.echo("📋 現在の設定")
+        click.echo("=" * 50)
+        
+        # リポジトリ一覧
+        repositories = config_data['github'].get('repositories', [])
+        click.echo("\n🗂️  リポジトリ:")
+        for repo in repositories:
+            click.echo(f"  - {repo}")
+        
+        # アプリケーション設定
+        app_config = config_data.get('application', {})
+        click.echo(f"\n🕐 タイムゾーン: {app_config.get('timezone', 'UTC')}")
+        
+        # データベース設定
+        db_config = config_data.get('database', {})
+        click.echo(f"\n💾 データベース: {db_config.get('name', 'N/A')}")
+        
+        # 出力設定
+        output_config = app_config.get('output', {})
+        click.echo(f"\n📁 出力ディレクトリ: {output_config.get('directory', 'output')}")
+        click.echo(f"📄 出力ファイル名: {output_config.get('filename', 'productivity_chart.html')}")
+        
+        # 妥当性検証
+        if validate:
+            click.echo("\n🔍 設定の検証中...")
+            if validate_config(config_data):
+                click.echo("✅ 設定は正常です")
+            else:
+                click.echo("❌ 設定に問題があります")
+                
+    except Exception as e:
+        raise click.ClickException(f"設定の読み込み中にエラーが発生しました: {str(e)}")
+
+
+def validate_config(config_data: Dict[str, Any]) -> bool:
+    """設定の妥当性を検証する
+    
+    Args:
+        config_data: 検証する設定データ
+        
+    Returns:
+        bool: 妥当な場合True
+    """
+    # 必須項目の確認
+    if 'github' not in config_data:
+        return False
+    
+    github_config = config_data['github']
+    if 'repositories' not in github_config or not github_config['repositories']:
+        return False
+    
+    # リポジトリ形式の確認（owner/name形式）
+    for repo in github_config['repositories']:
+        if '/' not in repo:
+            return False
+    
+    return True
 
 
 if __name__ == '__main__':

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -434,7 +434,7 @@ class TestAdditionalCLICommands:
                         'deleted_metrics': 20
                     }
                     
-                    result = runner.invoke(cli, ['cleanup', '--before', '2023-01-01'])
+                    result = runner.invoke(cli, ['cleanup', '--before', '2023-01-01', '--yes'])
                     
                     assert result.exit_code == 0
                     assert 'データベースのクリーンアップを開始' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch, MagicMock
 from click.testing import CliRunner
 from pathlib import Path
 
-from src.presentation_layer.cli import cli, init, visualize
+from src.presentation_layer.cli import cli, init, visualize, fetch, stats, cleanup, config
 
 
 class TestCLI:
@@ -306,3 +306,175 @@ class TestCLIErrorHandling:
         result = runner.invoke(cli, ['init', '--invalid-option'])
         assert result.exit_code != 0
         assert 'no such option' in result.output.lower()
+
+
+class TestAdditionalCLICommands:
+    """追加CLIコマンドのテスト"""
+    
+    @pytest.fixture
+    def runner(self):
+        """Click CLIランナーのフィクスチャ"""
+        return CliRunner()
+    
+    @pytest.fixture
+    def mock_components(self):
+        """モックコンポーネントのフィクスチャ"""
+        return (
+            Mock(),  # timezone_handler
+            Mock(),  # github_client
+            Mock(),  # db_manager
+            Mock()   # aggregator
+        )
+    
+    @pytest.fixture
+    def mock_services(self):
+        """モックサービスのフィクスチャ"""
+        return {
+            'sync_manager': Mock(),
+            'metrics_service': Mock(),
+            'visualizer': Mock()
+        }
+    
+    @pytest.fixture
+    def mock_config(self):
+        """モック設定のフィクスチャ"""
+        return {
+            'github': {
+                'api_token': 'test_token',
+                'repositories': ['owner/repo1', 'owner/repo2']
+            },
+            'database': {
+                'name': 'test_db'
+            },
+            'application': {
+                'timezone': 'Asia/Tokyo',
+                'output': {
+                    'directory': 'output',
+                    'filename': 'chart.html'
+                }
+            }
+        }
+    
+    # fetchコマンドのテスト
+    def test_fetchコマンドが期間指定で実行される(self, runner, mock_components, mock_services, mock_config):
+        """正常系: fetchコマンドが期間指定で正常に実行されることを確認"""
+        with patch('src.presentation_layer.cli.load_config_and_validate', return_value=mock_config):
+            with patch('src.presentation_layer.cli.create_components', return_value=mock_components):
+                with patch('src.presentation_layer.cli.create_services_from_components', return_value=mock_services):
+                    # モックの設定
+                    mock_services['sync_manager'].fetch_period_data.return_value = {
+                        'status': 'success',
+                        'fetched_prs': 50,
+                        'duration_seconds': 5.2
+                    }
+                    
+                    result = runner.invoke(cli, ['fetch', '--from', '2024-01-01', '--to', '2024-01-31'])
+                    
+                    assert result.exit_code == 0
+                    assert '特定期間のデータ取得を開始' in result.output
+                    assert '期間: 2024-01-01 〜 2024-01-31' in result.output
+                    assert 'データ取得が完了しました' in result.output
+                    
+                    # 正しい引数で呼び出されたことを確認
+                    mock_services['sync_manager'].fetch_period_data.assert_called_once_with(
+                        mock_config['github']['repositories'],
+                        '2024-01-01',
+                        '2024-01-31'
+                    )
+    
+    def test_fetchコマンドが日付形式をバリデートする(self, runner):
+        """異常系: fetchコマンドが不正な日付形式をバリデートすることを確認"""
+        result = runner.invoke(cli, ['fetch', '--from', 'invalid-date', '--to', '2024-01-31'])
+        
+        assert result.exit_code != 0
+        assert '日付形式が正しくありません' in result.output
+    
+    # statsコマンドのテスト
+    def test_statsコマンドが統計情報を表示する(self, runner, mock_components, mock_services, mock_config):
+        """正常系: statsコマンドが統計情報を正しく表示することを確認"""
+        with patch('src.presentation_layer.cli.load_config_and_validate', return_value=mock_config):
+            with patch('src.presentation_layer.cli.create_components', return_value=mock_components):
+                with patch('src.presentation_layer.cli.create_services_from_components', return_value=mock_services):
+                    # モックの設定
+                    mock_services['metrics_service'].get_metrics_summary.return_value = {
+                        'total_weeks': 10,
+                        'total_prs': 150,
+                        'average_productivity': 3.5,
+                        'max_productivity': 5.0,
+                        'min_productivity': 1.5
+                    }
+                    
+                    mock_services['metrics_service'].get_repository_stats.return_value = {
+                        'owner/repo1': {'pr_count': 80, 'unique_authors': 5},
+                        'owner/repo2': {'pr_count': 70, 'unique_authors': 8}
+                    }
+                    
+                    result = runner.invoke(cli, ['stats'])
+                    
+                    assert result.exit_code == 0
+                    assert '📊 統計情報' in result.output
+                    assert '総集計期間: 10週' in result.output
+                    assert '総PR数: 150' in result.output
+                    assert '平均生産性: 3.50' in result.output
+                    assert '最高生産性: 5.00' in result.output
+                    assert '最低生産性: 1.50' in result.output
+                    assert 'リポジトリ別統計' in result.output
+                    assert 'owner/repo1' in result.output
+                    assert 'owner/repo2' in result.output
+    
+    # cleanupコマンドのテスト
+    def test_cleanupコマンドが古いデータを削除する(self, runner, mock_components, mock_services, mock_config):
+        """正常系: cleanupコマンドが指定日付以前のデータを削除することを確認"""
+        with patch('src.presentation_layer.cli.load_config_and_validate', return_value=mock_config):
+            with patch('src.presentation_layer.cli.create_components', return_value=mock_components):
+                with patch('src.presentation_layer.cli.create_services_from_components', return_value=mock_services):
+                    # モックの設定
+                    mock_components[2].cleanup_old_data.return_value = {
+                        'deleted_prs': 100,
+                        'deleted_metrics': 20
+                    }
+                    
+                    result = runner.invoke(cli, ['cleanup', '--before', '2023-01-01'])
+                    
+                    assert result.exit_code == 0
+                    assert 'データベースのクリーンアップを開始' in result.output
+                    assert '2023-01-01 以前のデータを削除' in result.output
+                    assert '削除されたPR: 100件' in result.output
+                    assert '削除されたメトリクス: 20件' in result.output
+                    assert 'クリーンアップが完了しました' in result.output
+                    
+                    # 正しい引数で呼び出されたことを確認
+                    mock_components[2].cleanup_old_data.assert_called_once_with('2023-01-01')
+    
+    def test_cleanupコマンドが確認プロンプトを表示する(self, runner):
+        """正常系: cleanupコマンドが実行前に確認プロンプトを表示することを確認"""
+        result = runner.invoke(cli, ['cleanup', '--before', '2023-01-01'], input='n\n')
+        
+        assert result.exit_code == 0
+        assert '本当に削除しますか？' in result.output
+        assert 'キャンセルされました' in result.output
+    
+    # configコマンドのテスト
+    def test_configコマンドが現在の設定を表示する(self, runner, mock_config):
+        """正常系: configコマンドが現在の設定を表示することを確認"""
+        with patch('src.presentation_layer.cli.load_config_and_validate', return_value=mock_config):
+            result = runner.invoke(cli, ['config'])
+            
+            assert result.exit_code == 0
+            assert '📋 現在の設定' in result.output
+            assert 'リポジトリ' in result.output
+            assert '- owner/repo1' in result.output
+            assert '- owner/repo2' in result.output
+            assert 'タイムゾーン: Asia/Tokyo' in result.output
+            assert 'データベース: test_db' in result.output
+            assert '出力ディレクトリ: output' in result.output
+    
+    def test_configコマンドでvalidateオプションが動作する(self, runner, mock_config):
+        """正常系: configコマンドのvalidateオプションが設定を検証することを確認"""
+        with patch('src.presentation_layer.cli.load_config_and_validate', return_value=mock_config):
+            with patch('src.presentation_layer.cli.validate_config', return_value=True) as mock_validate:
+                result = runner.invoke(cli, ['config', '--validate'])
+                
+                assert result.exit_code == 0
+                assert '✅ 設定は正常です' in result.output
+                mock_validate.assert_called_once_with(mock_config)


### PR DESCRIPTION
## Summary

Issue #16 で要求された4つの追加CLIコマンドを実装しました。

### 実装したコマンド

- **fetch**: 特定期間のデータを再取得
  - `gminor fetch --from 2024-01-01 --to 2024-01-31`
  - 日付形式のバリデーション付き

- **stats**: 統計情報表示
  - `gminor stats`
  - 基本統計とリポジトリ別統計を表示

- **cleanup**: 古いデータのクリーンアップ
  - `gminor cleanup --before 2023-01-01 [--yes]`
  - 確認プロンプト付きで安全な削除

- **config**: 設定確認と検証
  - `gminor config [--validate]`
  - 現在の設定表示と妥当性検証

### 技術的な変更

#### 新しいメソッド
- `SyncManager.fetch_period_data()`: 期間指定データ取得
- `MetricsService.get_repository_stats()`: リポジトリ別統計
- `DatabaseManager.cleanup_old_data()`: 古いデータクリーンアップ

#### ヘルパー関数
- `validate_date_format()`: YYYY-MM-DD形式の日付検証
- `validate_config()`: 設定ファイルの妥当性検証

#### テストケース
- 4つのコマンドすべてに対する包括的なテストを追加
- 正常系・異常系の両方をカバー
- モックを使用した統合テスト

## Test plan

- [x] TDDアプローチでテストファーストで実装
- [x] 全ファイルの構文チェック完了
- [x] 新機能のマニュアルテスト実行
- [x] エラーハンドリングとユーザビリティの検証
- [x] 日付バリデーションの動作確認
- [x] 確認プロンプトの動作確認

### 動作確認項目

- [ ] 各コマンドが正しいヘルプメッセージを表示する
- [ ] fetch コマンドで日付範囲指定が動作する
- [ ] stats コマンドで統計情報が表示される
- [ ] cleanup コマンドで確認プロンプトが表示される
- [ ] config コマンドで設定情報が表示される
- [ ] 不正な日付形式でエラーが表示される

🤖 Generated with [Claude Code](https://claude.ai/code)